### PR TITLE
Assert that address list is not empty

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -128,6 +128,10 @@ impl FromHeader for Vec<Address> {
 
 impl ToFoldedHeader for Vec<Address> {
     fn to_folded_header(start_pos: usize, value: Vec<Address>) -> ParsingResult<String> {
+        if value.is_empty() {
+            return Err(ParsingError::new(format!("Header value cannot be empty")));
+        }
+
         let mut header = String::new();
 
         let mut line_len = start_pos;
@@ -407,5 +411,11 @@ mod tests {
         let header = Header::new_with_value("To".to_string(), addresses).unwrap();
         assert_eq!(&header.to_string()[..],
                    "To: =?utf-8?q?Joe_Blogs?= <joe@example.org>, \r\n\t=?utf-8?q?John_Doe?= <john@example.org>, \r\n\t=?utf-8?q?Mr_Black?= <mafia_black@example.org>");
+    }
+
+    #[test]
+    fn test_to_header_empty() {
+        let header = Header::new_with_value("To".to_string(), vec![]);
+        assert!(header.is_err());
     }
 }


### PR DESCRIPTION
Current code relies on it being non-empty, otherwise an integer overflow
is triggered. assert! makes sure no wrapping happens in release mode.